### PR TITLE
chore: 更新.gitignore并允许Swagger UI的无认证访问

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### IDE History Files ###
+.history/

--- a/src/main/java/com/example/lost_and_found/config/SecurityConfig.java
+++ b/src/main/java/com/example/lost_and_found/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login").permitAll()
+                        .requestMatchers("/login", "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception ->


### PR DESCRIPTION
在.gitignore中添加.history/目录以忽略IDE历史文件
修改SecurityConfig.java以允许对Swagger UI相关端点的无认证访问